### PR TITLE
Avatar accessibility

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const action = {
   token: getInput('token'),
   template: !isNullOrUndefined(getInput('template'))
     ? getInput('template')
-    : `<a href="https://github.com/{{{ login }}}"><img src="https://github.com/{{{ login }}}.png" width="60px" alt="" /></a>`,
+    : `<a href="https://github.com/{{{ login }}}"><img src="https://github.com/{{{ login }}}.png" width="60px" alt="{{{ name }}}" /></a>`,
   minimum: !isNullOrUndefined(getInput('minimum'))
     ? parseInt(getInput('minimum'))
     : 0,


### PR DESCRIPTION
## Description

The `img alt` should ideally contain the user's name (or login, again, as a worstcase maybe?)

## Testing Instructions

I'm unsure now with the `name` being _null_ sometimes this is the best way, maybe just repeating `login` again, for accessibility/readability fallback, is the most bulletproof way?

## Additional Notes

Or if this has more elegant or universal solution, just ignore this;) … it's more of an a11y note than a proper solution for it.