### PR TITLE
feat: fall back to `url` if `websiteUrl` is null

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -123,6 +123,7 @@ export function generateTemplate(
     }
 
     filteredSponsors.map(({sponsorEntity}) => {
+      sponsorEntity.websiteUrl = sponsorEntity.websiteUrl || sponsorEntity.url
       template = template += render(action.template, sponsorEntity)
     })
   } else {


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->

Fall back to `url` if sponsors `websiteUrl` is null.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

Example config:

```yml
- name: Update `Sponsors` section (Bronze)
  uses: JamesIves/github-sponsors-readme-action@v1
  with:
    token: ${{ secrets.PAT }}
    file: 'README.md'
    template: '<a href="{{{ websiteUrl }}}"><img src="https://github.com/{{{ login }}}.png" alt="{{{ login }}}" width="50px"></a>'
```

`websiteUrl` should be replaced with `url` if the `websiteUrl` of a sponsor is null.

## Additional Notes

<!-- Anything else that will help us test the pull request. -->
