### PR TITLE
Use jest/recommended ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,15 @@
 {
-  "plugins": ["jest", "@typescript-eslint"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:jest/recommended"
   ],
-  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 9,
-    "sourceType": "module",
     "project": "./tsconfig.lint.json"
   },
-  "globals": {
-    "fetch": true
-  },
   "env": {
-    "node": true,
-    "es6": true,
-    "jest/globals": true
+    "node": true
   },
   "rules": {
     "@typescript-eslint/ban-types": [

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -5,7 +5,7 @@ import {GitHubResponse, PrivacyLevel, Urls} from '../src/constants'
 import run from '../src/lib'
 import '../src/main'
 
-export const response: GitHubResponse = {
+const response: GitHubResponse = {
   data: {
     viewer: {
       sponsorshipsAsMaintainer: {
@@ -118,10 +118,7 @@ describe('lib', () => {
       fallback: ''
     }
 
-    try {
-      await run(action)
-    } catch (error) {
-      expect(setFailed).toBeCalled()
-    }
+    await expect(run(action)).rejects.toThrow()
+    expect(setFailed).toHaveBeenCalled()
   })
 })

--- a/__tests__/template.test.ts
+++ b/__tests__/template.test.ts
@@ -610,13 +610,9 @@ describe('template', () => {
         fallback: 'There are no sponsors in this tier'
       }
 
-      try {
-        await generateFile(response, action)
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          'There was an error generating the updated file: Mocked throw ❌'
-        )
-      }
+      await expect(generateFile(response, action)).rejects.toThrow(
+        'There was an error generating the updated file: Mocked throw ❌'
+      )
     })
   })
 
@@ -682,13 +678,9 @@ describe('template', () => {
         fallback: 'There are no sponsors in this tier'
       }
 
-      try {
-        await getSponsors(action)
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          'There was an error with the GitHub API request: Mocked throw ❌'
-        )
-      }
+      await expect(getSponsors(action)).rejects.toThrow(
+        'There was an error with the GitHub API request: Mocked throw ❌'
+      )
     })
   })
 })

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -40,13 +40,9 @@ describe('util', () => {
         fallback: ''
       }
 
-      try {
-        checkParameters(action)
-      } catch (error) {
-        expect(extractErrorMessage(error)).toMatch(
-          'No deployment token was provided. You must provide the action with a Personal Access Token scoped to user:read or org:read.'
-        )
-      }
+      expect(() => checkParameters(action)).toThrow(
+        'No deployment token was provided. You must provide the action with a Personal Access Token scoped to user:read or org:read.'
+      )
     })
 
     it('should not fail if it has all of the parameters', () => {


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->
We have `eslint-plugin-jest` installed, but we don't have any of its rules configured. I enabled the `jest/recommended` config to help fix some bugs I noticed in the tests. Some tests are now failing due to bugs in the implementation that are surfaced by fixed tests.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->
Run Jest and ESLint

## Additional Notes

<!-- Anything else that will help us test the pull request. -->
Discovered in #486