### PR TITLE
feat: ✨  allow active-only input

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The following options must be configured.
 | `marker`       | This allows you to modify the marker comment that is placed in your file. By default this is set to sponsors - `<!-- sponsors --> <!-- sponsors -->`, if you set this to `gold` for example you can place `<!-- gold --> <!-- gold -->` in your file.             | `with` | **No**   |
 | `fallback`     | Allows you to specify a fallback if you have no sponsors. By default nothing is displayed.                                                                                                                                                                        | `with` | **No**   |
 | `template`     | Allows you to modify the default template. Please refer to the `template` section of this README for more information.                                                                                                                                            | `with` | **No**   |
+| `active-only`     | If set to `false`, inactive sponsors will be displayed. This can be useful if you want to display all sponsors, regardless of their status. By default this is set to `true`.                                                                                                                                            | `with` | **No**   |
 
 #### Deployment Status
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 You can include the action in your workflow to trigger on any event that [GitHub Actions supports](https://help.github.com/en/articles/events-that-trigger-workflows).
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > You'll need to provide the action with a **Personal Access Token (PAT)** scoped to `read:user` and `read:org`. This action only applies the template within the workspace. You will need to combine it with a deployment action in order to commit it to your project. You can see a full example of this below.
 
 ```yml
@@ -133,7 +133,7 @@ The following options must be configured.
 | `marker`       | This allows you to modify the marker comment that is placed in your file. By default this is set to sponsors - `<!-- sponsors --> <!-- sponsors -->`, if you set this to `gold` for example you can place `<!-- gold --> <!-- gold -->` in your file.             | `with` | **No**   |
 | `fallback`     | Allows you to specify a fallback if you have no sponsors. By default nothing is displayed.                                                                                                                                                                        | `with` | **No**   |
 | `template`     | Allows you to modify the default template. Please refer to the `template` section of this README for more information.                                                                                                                                            | `with` | **No**   |
-| `active-only`     | If set to `false`, inactive sponsors will be displayed. This can be useful if you want to display all sponsors, regardless of their status. By default this is set to `true`.                                                                                                                                            | `with` | **No**   |
+| `active-only`  | If set to `false`, inactive sponsors will be displayed. This can be useful if you want to display all sponsors, regardless of their status. By default this is set to `true`.                                                                                     | `with` | **No**   |
 
 #### Deployment Status
 

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -75,7 +75,8 @@ describe('lib', () => {
       maximum: 0,
       marker: 'sponsor',
       organization: false,
-      fallback: ''
+      fallback: '',
+      activeOnly: true
     }
 
     // Valid file structure
@@ -97,7 +98,8 @@ describe('lib', () => {
       maximum: 0,
       marker: 'sponsors',
       organization: false,
-      fallback: ''
+      fallback: '',
+      activeOnly: true
     }
 
     // Purposely write incorrect data
@@ -115,7 +117,8 @@ describe('lib', () => {
       maximum: 0,
       marker: 'sponsors',
       organization: false,
-      fallback: ''
+      fallback: '',
+      activeOnly: true
     }
 
     try {

--- a/__tests__/template.test.ts
+++ b/__tests__/template.test.ts
@@ -64,7 +64,8 @@ describe('template', () => {
         maximum: 0,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -123,7 +124,8 @@ describe('template', () => {
         maximum: 0,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -182,7 +184,8 @@ describe('template', () => {
         maximum: 0,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -241,7 +244,8 @@ describe('template', () => {
         maximum: 0,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -300,7 +304,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -359,7 +364,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -418,7 +424,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: false,
-        fallback: 'There are no sponsors in this tier'
+        fallback: 'There are no sponsors in this tier',
+        activeOnly: true
       }
 
       expect(generateTemplate(response, action)).toEqual(action.fallback)
@@ -477,7 +484,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: false,
-        fallback: 'There are no sponsors in this tier'
+        fallback: 'There are no sponsors in this tier',
+        activeOnly: true
       }
 
       // Write temp README file for testing
@@ -540,7 +548,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: false,
-        fallback: 'There are no sponsors in this tier'
+        fallback: 'There are no sponsors in this tier',
+        activeOnly: true
       }
 
       // Purposely write incorrect data
@@ -607,7 +616,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: false,
-        fallback: 'There are no sponsors in this tier'
+        fallback: 'There are no sponsors in this tier',
+        activeOnly: true
       }
 
       try {
@@ -631,7 +641,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: false,
-        fallback: 'There are no sponsors in this tier'
+        fallback: 'There are no sponsors in this tier',
+        activeOnly: true
       }
 
       nock(Urls.GITHUB_API).post('/graphql').reply(200, {
@@ -653,7 +664,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: true,
-        fallback: 'There are no sponsors in this tier'
+        fallback: 'There are no sponsors in this tier',
+        activeOnly: true
       }
 
       nock(Urls.GITHUB_API).post('/graphql').reply(200, {
@@ -679,7 +691,8 @@ describe('template', () => {
         maximum: 10000,
         marker: 'sponsors',
         organization: true,
-        fallback: 'There are no sponsors in this tier'
+        fallback: 'There are no sponsors in this tier',
+        activeOnly: true
       }
 
       try {

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -37,7 +37,8 @@ describe('util', () => {
         maximum: 0,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       try {
@@ -58,7 +59,8 @@ describe('util', () => {
         maximum: 0,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       const response = checkParameters(action)
@@ -76,7 +78,8 @@ describe('util', () => {
         maximum: 0,
         marker: 'sponsors',
         organization: false,
-        fallback: ''
+        fallback: '',
+        activeOnly: true
       }
 
       const string = `This is an error message! It contains ${action.token} and ${action.token} again!`

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,11 @@ inputs:
     description: Allows you to specify a fallback if you have no sponsors. By default nothing is displayed.
     required: false
 
+  active-only:
+    description: If set to false, inactive sponsors will be displayed. This can be useful if you want to display all sponsors, regardless of their status.
+    default: 'true'
+    required: false
+
 outputs:
   sponsorshipStatus:
     description: 'The status of the action that indicates if the run failed or passed. Possible outputs include: success|failed'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,8 @@ export interface ActionInterface {
   fallback: string
   /** Fetches organization level sponsors if true. */
   organization: boolean
+  /** Determines if inactive sponsors should be returned or not. */
+  activeOnly: boolean
 }
 
 /**
@@ -46,6 +48,9 @@ export const action = {
     : ``,
   organization: !isNullOrUndefined(getInput('organization'))
     ? getInput('organization').toLowerCase() === 'true'
+    : false,
+  activeOnly: !isNullOrUndefined(getInput('active-only'))
+    ? getInput('active-only').toLowerCase() === 'true'
     : false
 }
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -32,7 +32,9 @@ export async function getSponsors(
           : `viewer`
       } {
         login
-        sponsorshipsAsMaintainer(first: 100, orderBy: {field: CREATED_AT, direction: ASC}, includePrivate: true, activeOnly: ${action.activeOnly}) {
+        sponsorshipsAsMaintainer(first: 100, orderBy: {field: CREATED_AT, direction: ASC}, includePrivate: true, activeOnly: ${
+          action.activeOnly
+        }) {
           totalCount
           pageInfo {
             endCursor

--- a/src/template.ts
+++ b/src/template.ts
@@ -32,7 +32,7 @@ export async function getSponsors(
           : `viewer`
       } {
         login
-        sponsorshipsAsMaintainer(first: 100, orderBy: {field: CREATED_AT, direction: ASC}, includePrivate: true) {
+        sponsorshipsAsMaintainer(first: 100, orderBy: {field: CREATED_AT, direction: ASC}, includePrivate: true, activeOnly: ${action.activeOnly}) {
           totalCount
           pageInfo {
             endCursor


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->

Implements the `active-only` input, allowing you to display past sponsors. This is useful if you'd prefer to give credit to your projects to _everyone_ who has previously donated, regardless of their current status.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

N/A

## Additional Notes

<!-- Anything else that will help us test the pull request. -->

Closes #730 
