### PR TITLE
feat: ✨ Adds ability to display anonymized private sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ You can modify the template that gets generated in your file by using the `templ
 | `name`       | The users full name. This can sometimes be `null` if the user hasn't set one. This can be accessed using `{{ name }}`                                                    |
 | `login`      | The users login, this can be accessed using `{{ login }}`                                                                                                                |
 | `url`        | The users GitHub profile url, this can be accessed using `{{ url }}`.                                                                                                    |
+| `avatarUrl`  | The users avatar url, this can be accessed using `{{ avatarUrl }}`.                                                                                                      |
 | `websiteUrl` | The users website url. This can sometimes be `null` if the user hasn't set one, if so this field will fall back to `url`. This can be accessed using `{{ websiteUrl }}`. |
 
 You're able to use markdown or GitHub approved basic HTML. The default template can be found [here](./src/constants.ts#L28).

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -24,7 +24,8 @@ const response: GitHubResponse = {
               name: 'James Ives',
               login: 'JamesIves',
               url: 'https://github.com/JamesIves',
-              websiteUrl: 'https://jamesiv.es'
+              websiteUrl: 'https://jamesiv.es',
+              avatarUrl: 'https://avatars.githubusercontent.com/u/10888441?v=4'
             }
           },
           {
@@ -37,7 +38,8 @@ const response: GitHubResponse = {
               name: 'Montezuma Ives',
               login: 'MontezumaIves',
               url: 'https://github.com/MontezumaIves',
-              websiteUrl: 'https://jamesiv.es'
+              websiteUrl: 'https://jamesiv.es',
+              avatarUrl: 'https://avatars.githubusercontent.com/u/78580739?v=4'
             }
           }
         ]
@@ -76,7 +78,8 @@ describe('lib', () => {
       marker: 'sponsors',
       organization: false,
       fallback: '',
-      activeOnly: true
+      activeOnly: true,
+      includePrivate: false
     }
 
     // Valid file structure
@@ -101,7 +104,8 @@ describe('lib', () => {
       marker: 'fake-marker',
       organization: false,
       fallback: '',
-      activeOnly: true
+      activeOnly: true,
+      includePrivate: false
     }
 
     // Purposely write incorrect data
@@ -122,7 +126,8 @@ describe('lib', () => {
       marker: 'sponsors',
       organization: false,
       fallback: '',
-      activeOnly: true
+      activeOnly: true,
+      includePrivate: false
     }
 
     try {

--- a/__tests__/template.test.ts
+++ b/__tests__/template.test.ts
@@ -33,7 +33,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -46,7 +48,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -65,7 +69,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -93,7 +98,9 @@ describe('template', () => {
                     name: '><h1>HELLO!!!!</h1>',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -106,7 +113,9 @@ describe('template', () => {
                     name: '><h1>HELLO!!!!</h1>',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves"><h1>HELLO!!!!</h1>',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -125,7 +134,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -153,7 +163,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: null
+                    websiteUrl: null,
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -166,7 +178,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: null
+                    websiteUrl: null,
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -185,7 +199,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -213,7 +228,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -226,7 +243,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -245,11 +264,77 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       expect(generateTemplate(response, action)).toEqual(
         '<a href="https://github.com/JamesIves"><img src="https://github.com/JamesIves.png" width="60px" alt="" /></a>'
+      )
+    })
+
+    it('should anonymize private data if includePrivate is true', () => {
+      const response: GitHubResponse = {
+        data: {
+          viewer: {
+            sponsorshipsAsMaintainer: {
+              totalCount: 2,
+              pageInfo: {
+                endCursor: 'MQ'
+              },
+              nodes: [
+                {
+                  createdAt: '123',
+                  privacyLevel: PrivacyLevel.PUBLIC,
+                  tier: {
+                    monthlyPriceInCents: 5000
+                  },
+                  sponsorEntity: {
+                    name: 'James Ives',
+                    login: 'JamesIves',
+                    url: 'https://github.com/JamesIves',
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
+                  }
+                },
+                {
+                  createdAt: '123',
+                  privacyLevel: PrivacyLevel.PRIVATE,
+                  tier: {
+                    monthlyPriceInCents: 5000
+                  },
+                  sponsorEntity: {
+                    name: 'Montezuma Ives',
+                    login: 'MontezumaIves',
+                    url: 'https://github.com/MontezumaIves',
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      const action = {
+        token: '123',
+        file: 'README.test.md',
+        template:
+          '<a href="https://github.com/{{ login }}"><img src="{{ avatarUrl }}" width="60px" alt="" /></a>',
+        minimum: 0,
+        maximum: 0,
+        marker: 'sponsors',
+        organization: false,
+        fallback: '',
+        activeOnly: true,
+        includePrivate: true
+      }
+
+      expect(generateTemplate(response, action)).toEqual(
+        '<a href="https://github.com/JamesIves"><img src="https:&#x2F;&#x2F;avatars.githubusercontent.com&#x2F;u&#x2F;10888441?v&#x3D;4" width="60px" alt="" /></a><a href="https://github.com/"><img src="https:&#x2F;&#x2F;raw.githubusercontent.com&#x2F;JamesIves&#x2F;github-sponsors-readme-action&#x2F;dev&#x2F;.github&#x2F;assets&#x2F;placeholder.png" width="60px" alt="" /></a>'
       )
     })
 
@@ -273,7 +358,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -286,7 +373,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -305,7 +394,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: true
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -333,7 +423,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -346,7 +438,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -365,7 +459,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -393,7 +488,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -406,7 +503,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -425,7 +524,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       expect(generateTemplate(response, action)).toEqual(
@@ -453,7 +553,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -466,7 +568,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -485,7 +589,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: 'There are no sponsors in this tier',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       expect(generateTemplate(response, action)).toEqual(action.fallback)
@@ -513,7 +618,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 },
                 {
@@ -526,7 +633,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -545,7 +654,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: 'There are no sponsors in this tier',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       // Write temp README file for testing
@@ -577,7 +687,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -590,7 +702,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -609,7 +723,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: 'There are no sponsors in this tier',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       // Purposely write incorrect data
@@ -645,7 +760,9 @@ describe('template', () => {
                     name: 'James Ives',
                     login: 'JamesIves',
                     url: 'https://github.com/JamesIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/10888441?v=4'
                   }
                 },
                 {
@@ -658,7 +775,9 @@ describe('template', () => {
                     name: 'Montezuma Ives',
                     login: 'MontezumaIves',
                     url: 'https://github.com/MontezumaIves',
-                    websiteUrl: 'https://jamesiv.es'
+                    websiteUrl: 'https://jamesiv.es',
+                    avatarUrl:
+                      'https://avatars.githubusercontent.com/u/78580739?v=4'
                   }
                 }
               ]
@@ -677,7 +796,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: 'There are no sponsors in this tier',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       try {
@@ -702,7 +822,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: false,
         fallback: 'There are no sponsors in this tier',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       nock(Urls.GITHUB_API).post('/graphql').reply(200, {
@@ -725,7 +846,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: true,
         fallback: 'There are no sponsors in this tier',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       nock(Urls.GITHUB_API).post('/graphql').reply(200, {
@@ -752,7 +874,8 @@ describe('template', () => {
         marker: 'sponsors',
         organization: true,
         fallback: 'There are no sponsors in this tier',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       try {

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -38,7 +38,8 @@ describe('util', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       try {
@@ -60,7 +61,8 @@ describe('util', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       const response = checkParameters(action)
@@ -79,7 +81,8 @@ describe('util', () => {
         marker: 'sponsors',
         organization: false,
         fallback: '',
-        activeOnly: true
+        activeOnly: true,
+        includePrivate: false
       }
 
       const string = `This is an error message! It contains ${action.token} and ${action.token} again!`

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,11 @@ inputs:
     default: 'true'
     required: false
 
+  include-private:
+    description: If set to true, private sponsors will be displayed in the list, however any identifying information will be redacted. This can be useful if you want to display all sponsors, regardless of their privacy settings.
+    default: 'false'
+    required: false
+
 outputs:
   sponsorshipStatus:
     description: 'The status of the action that indicates if the run failed or passed. Possible outputs include: success|failed'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,9 @@ export interface ActionInterface {
   organization: boolean
   /** Determines if inactive sponsors should be returned or not. */
   activeOnly: boolean
+  /** Determines if private sponsors should be returned or not. If marked as true, the identity of the sponsor is still
+    kept private, however, an anonymized version of the sponsor is still included in the list. */
+  includePrivate: boolean
 }
 
 /**
@@ -32,7 +35,7 @@ export const action = {
   token: getInput('token'),
   template: !isNullOrUndefined(getInput('template'))
     ? getInput('template')
-    : `<a href="https://github.com/{{ login }}"><img src="https://github.com/{{ login }}.png" width="60px" alt="{{ name }}" /></a>`,
+    : `<a href="https://github.com/{{ login }}"><img src="{{ avatarUrl }}" width="60px" alt="{{ name }}" /></a>`,
   minimum: !isNullOrUndefined(getInput('minimum'))
     ? parseInt(getInput('minimum'))
     : 0,
@@ -51,6 +54,9 @@ export const action = {
     : false,
   activeOnly: !isNullOrUndefined(getInput('active-only'))
     ? getInput('active-only').toLowerCase() === 'true'
+    : false,
+  includePrivate: !isNullOrUndefined(getInput('include-private'))
+    ? getInput('include-private').toLowerCase() === 'true'
     : false
 }
 
@@ -62,6 +68,7 @@ export interface Sponsor {
     name: string | null
     login: string
     url: string
+    avatarUrl: string
     websiteUrl: string | null
   }
   createdAt: string


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->

This updates allows you to mirror the GitHub Sponsors UI when a user is sponsoring as private. The action will now _display_ private sponsors if `include-private` is set to `true`, however it will anonymize all identifying user information to properly respect privacy. 

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

You can see an example of what this look like below:

<img width="861" alt="Screenshot 2024-09-01 at 8 58 08 AM" src="https://github.com/user-attachments/assets/4f8a635f-420b-4e1b-9418-b5d97cbde679">


## Additional Notes

<!-- Anything else that will help us test the pull request. -->
